### PR TITLE
Chore/readme line length

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 <div align="center">
   <a href="https://github.com/frack113/MalwareTracesGenerator/">
-    <img src="https://raw.githubusercontent.com/frack113/MalwareTracesGenerator/refs/heads/main/media/logo.svg" alt="Logo" />
+    <img src="https://raw.githubusercontent.com/frack113/MalwareTracesGenerator/
+refs/heads/main/media/logo.svg" alt="Logo" />
   </a>
 
 <h3 align="center">Malware Traces Generator</h3>
@@ -24,19 +25,24 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <br />
     <br />
     <a href="https://github.com/">
-      <img src="https://img.shields.io/badge/GitHub-181717?logo=github&logoColor=fff&style=for-the-badge" alt="Github badge" />
+      <img src="https://img.shields.io/badge/GitHub-181717?logo=github&logoColor
+=fff&style=for-the-badge" alt="Github badge" />
     </a>
     <a href="./LICENSES/GPL-3.0-or-later.txt">
-      <img src="https://img.shields.io/badge/License-GPL%203.0%20or%20later-green.svg?style=for-the-badge" alt="GPL 3.0 or later badge" />
+      <img src="https://img.shields.io/badge/License-GPL%203.0%20or%20later-gree
+n.svg?style=for-the-badge" alt="GPL 3.0 or later badge" />
     </a>
     <a href="https://www.microsoft.com/en-us/windows/">
-      <img src="https://img.shields.io/badge/Windows-0078D4?logo=windows&logoColor=fff&style=for-the-badge" alt="Windows badge" />
+      <img src="https://img.shields.io/badge/Windows-0078D4?logo=windows&logoCol
+or=fff&style=for-the-badge" alt="Windows badge" />
     </a>
     <a href="https://www.rust-lang.org/">
-      <img src="https://img.shields.io/badge/Rust-000?logo=rust&logoColor=fff&style=for-the-badge" alt="Rust badge" />
+      <img src="https://img.shields.io/badge/Rust-000?logo=rust&logoColor=fff&st
+yle=for-the-badge" alt="Rust badge" />
     </a>
     <a href="https://reuse.software/">
-      <img src="https://img.shields.io/reuse/compliance/github.com%2Ffrack113%2FWAG?style=for-the-badge" alt="Reuse badge" />
+      <img src="https://img.shields.io/reuse/compliance/github.com%2Ffrack113%2F
+WAG?style=for-the-badge" alt="Reuse badge" />
     </a>
   </p>
 </div>
@@ -57,13 +63,17 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## 👀 About the project
 
-[Malware Traces Generator][mtg] is a tool for creating malware traces for detection tests.
+[Malware Traces Generator][mtg] is a tool for creating malware traces for
+detection tests.
 
 ### ❓ Why
 
-It's useful for testing configurations, rules, or your Endpoint Detection and Response. \
-It's not intended to fully simulate the behavior of malware but to reproduce the steps that led to traces creation. \
-By avoiding full and complex simulations, [Malware Traces Generator][mtg] seeks to be simple but nonetheless powerful.
+It's useful for testing configurations, rules, or your Endpoint Detection and
+Response.
+It's not intended to fully simulate the behavior of malware but to reproduce the
+steps that led to traces creation.
+By avoiding full and complex simulations, [Malware Traces Generator][mtg] seeks
+to be simple but nonetheless powerful.
 
 ## 🚀 Getting started
 
@@ -102,7 +112,8 @@ After these steps, the application will be in the target directory.
 
 ### 🥷 Quick examples
 
-Now that [Malware Traces Generator][mtg] is installed, you can start generating some traces! \
+Now that [Malware Traces Generator][mtg] is installed, you can start generating
+some traces!
 For example, you can create a file like this:
 
 ```sh
@@ -119,7 +130,8 @@ To see more information about what you can do, see the [documentation].
 
 ## 👷 Contributing
 
-Contributions are what make the open source community such an amazing place to learn, inspire, and create. \
+Contributions are what make the open source community such an amazing place to
+learn, inspire, and create.
 Any contributions you make are **greatly appreciated**.
 
 If you want, you can help me with any kind of work, for example:

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ detection tests.
 ### ❓ Why
 
 It's useful for testing configurations, rules, or your Endpoint Detection and
-Response.
+Response.\
 It's not intended to fully simulate the behavior of malware but to reproduce the
-steps that led to traces creation.
+steps that led to traces creation.\
 By avoiding full and complex simulations, [Malware Traces Generator][mtg] seeks
 to be simple but nonetheless powerful.
 
@@ -81,12 +81,12 @@ This is an example of how you can install or build the project yourself.
 
 ### ⚙️ Prerequisites
 
-Depending on what you want to achieve, you might need different tools. \
+Depending on what you want to achieve, you might need different tools.\
 For now, you only need [Cargo] to build or install the project.
 
 ### 📦 Installation
 
-Currently, this project is only available on [crates.io]. \
+Currently, this project is only available on [crates.io].\
 In order to install it, just enter this command in your favorite terminal:
 
 ```sh
@@ -113,7 +113,7 @@ After these steps, the application will be in the target directory.
 ### 🥷 Quick examples
 
 Now that [Malware Traces Generator][mtg] is installed, you can start generating
-some traces!
+some traces!\
 For example, you can create a file like this:
 
 ```sh
@@ -131,7 +131,7 @@ To see more information about what you can do, see the [documentation].
 ## 👷 Contributing
 
 Contributions are what make the open source community such an amazing place to
-learn, inspire, and create.
+learn, inspire, and create.\
 Any contributions you make are **greatly appreciated**.
 
 If you want, you can help me with any kind of work, for example:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 <div align="center">
   <a href="https://github.com/frack113/MalwareTracesGenerator/">
-    <img src="https://raw.githubusercontent.com/frack113/MalwareTracesGenerator/
-refs/heads/main/media/logo.svg" alt="Logo" />
+      <!-- markdownlint-disable line-length -->
+    <img src="https://raw.githubusercontent.com/frack113/MalwareTracesGenerator/refs/heads/main/media/logo.svg" alt="Logo"/>
   </a>
 
 <h3 align="center">Malware Traces Generator</h3>
@@ -25,24 +25,24 @@ refs/heads/main/media/logo.svg" alt="Logo" />
     <br />
     <br />
     <a href="https://github.com/">
-      <img src="https://img.shields.io/badge/GitHub-181717?logo=github&logoColor
-=fff&style=for-the-badge" alt="Github badge" />
+      <!-- markdownlint-disable line-length -->
+      <img src="https://img.shields.io/badge/GitHub-181717?logo=github&logoColor=fff&style=for-the-badge" alt="Github badge" />
     </a>
     <a href="./LICENSES/GPL-3.0-or-later.txt">
-      <img src="https://img.shields.io/badge/License-GPL%203.0%20or%20later-gree
-n.svg?style=for-the-badge" alt="GPL 3.0 or later badge" />
+      <!-- markdownlint-disable line-length -->
+      <img src="https://img.shields.io/badge/License-GPL%203.0%20or%20later-green.svg?style=for-the-badge" alt="GPL 3.0 or later badge" />
     </a>
     <a href="https://www.microsoft.com/en-us/windows/">
-      <img src="https://img.shields.io/badge/Windows-0078D4?logo=windows&logoCol
-or=fff&style=for-the-badge" alt="Windows badge" />
+      <!-- markdownlint-disable line-length -->
+      <img src="https://img.shields.io/badge/Windows-0078D4?logo=windows&logoColor=fff&style=for-the-badge" alt="Windows badge" />
     </a>
     <a href="https://www.rust-lang.org/">
-      <img src="https://img.shields.io/badge/Rust-000?logo=rust&logoColor=fff&st
-yle=for-the-badge" alt="Rust badge" />
+      <!-- markdownlint-disable line-length -->
+      <img src="https://img.shields.io/badge/Rust-000?logo=rust&logoColor=fff&style=for-the-badge" alt="Rust badge" />
     </a>
     <a href="https://reuse.software/">
-      <img src="https://img.shields.io/reuse/compliance/github.com%2Ffrack113%2F
-WAG?style=for-the-badge" alt="Reuse badge" />
+      <!-- markdownlint-disable line-length -->
+      <img src="https://img.shields.io/reuse/compliance/github.com%2Ffrack113%2FWAG?style=for-the-badge" alt="Reuse badge" />
     </a>
   </p>
 </div>


### PR DESCRIPTION
I disable line-length rule for URLs, we can't split them in multiple parts without breaking the URL in HTML