### PR TITLE
ci: 🤖 Make step names more uniform with other workflow

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -8,7 +8,7 @@ permissions:
 on: [push, pull_request]
 jobs:
   yamlfix:
-    name: Check YAML formatting
+    name: Check formatting with yamlfix
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -21,7 +21,7 @@ jobs:
       - name: Check YAML formatting
         run: uvx yamlfix -v --check .
   mdformat:
-    name: Check Markdown formatting
+    name: Check formatting with mdformat
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -34,7 +34,7 @@ jobs:
       - name: Check Markdown formatting
         run: uvx mdformat --check .
   rustfmt:
-    name: Check Rust formatting
+    name: Check formatting with rustfmt
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
@@ -48,7 +48,7 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt -v --all -- --check
   taplo:
-    name: Check TOML formatting
+    name: Check formatting with taplo
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
I noticed that names in format workflow are not in the same format as in other workflows